### PR TITLE
Users can either be riders or drivers when creating an account

### DIFF
--- a/trips/models.py
+++ b/trips/models.py
@@ -7,7 +7,10 @@ from django.urls import reverse
 
 
 class User(AbstractUser):
-    pass
+    @property
+    def group(self):
+        groups = self.groups.all()
+        return groups[0].name if groups else None
 
 
 class Trip(models.Model):

--- a/trips/serializers.py
+++ b/trips/serializers.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from rest_framework import serializers
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
@@ -8,6 +9,10 @@ from .models import Trip
 class UserSerializer(serializers.ModelSerializer):
     password1 = serializers.CharField(write_only=True)
     password2 = serializers.CharField(write_only=True)
+    group = serializers.ChoiceField(choices=[
+        ('rider', 'Rider'),
+        ('driver', 'Driver')
+    ])
 
     def validate(self, data):
         if data['password1'] != data['password2']:
@@ -16,17 +21,26 @@ class UserSerializer(serializers.ModelSerializer):
         return data
 
     def create(self, validated_data):
+        group_data = validated_data.pop('group')
+
+        group, _ = Group.objects.get_or_create(name=group_data)
+
         data = {
             key: value for key, value in validated_data.items() if key not in ('password1', 'password2')
         }
 
         data['password'] = validated_data['password1']
-        return self.Meta.model.objects.create_user(**data)
+
+        user = self.Meta.model.objects.create_user(**data)
+        user.groups.add(group)
+        user.save()
+
+        return user
 
     class Meta:
         model = get_user_model()
         fields = (
-            'id', 'username', 'password1', 'password2', 'first_name', 'last_name'
+            'id', 'username', 'password1', 'password2', 'first_name', 'last_name', 'group'
         )
 
         read_only_fields = ('id',)


### PR DESCRIPTION
- User model has a group property set for each user
- Users specify their role when creating an account
- Riders can view all trips they requested
- Drivers can view all requested trips, and they can view all trips they accepted
- Update tests to reflect changes